### PR TITLE
Authorization changes

### DIFF
--- a/src/main/java/com/example/pizzaproject/auth/JwtResponse.java
+++ b/src/main/java/com/example/pizzaproject/auth/JwtResponse.java
@@ -3,6 +3,13 @@ package com.example.pizzaproject.auth;
 public class JwtResponse {
     private String JWTToken;
     private String status;
+    private String RefreshToken;
+
+    public JwtResponse(String status, String JWTToken, String RefreshToken) {
+        this.status = status;
+        this.JWTToken = JWTToken;
+        this.RefreshToken = RefreshToken;
+    }
 
     public String getStatus() {
         return status;
@@ -12,16 +19,19 @@ public class JwtResponse {
         this.status = status;
     }
 
-    public JwtResponse(String status, String JWTToken) {
-        this.status = status;
-        this.JWTToken = JWTToken;
-    }
-
     public String getJWTToken() {
         return JWTToken;
     }
 
     public void setJWTToken(String JWTToken) {
         this.JWTToken = JWTToken;
+    }
+
+    public String getRefreshToken() {
+        return RefreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        RefreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/example/pizzaproject/auth/RefreshRequest.java
+++ b/src/main/java/com/example/pizzaproject/auth/RefreshRequest.java
@@ -1,0 +1,20 @@
+package com.example.pizzaproject.auth;
+
+public class RefreshRequest {
+    private String refreshToken;
+
+    public RefreshRequest() {
+    }
+
+    public RefreshRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/pizzaproject/auth/RefreshUtil.java
+++ b/src/main/java/com/example/pizzaproject/auth/RefreshUtil.java
@@ -2,7 +2,6 @@ package com.example.pizzaproject.auth;
 
 import com.example.pizzaproject.user.User;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.stereotype.Component;
@@ -10,15 +9,16 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 
 @Component
-public class JwtUtil {
-    private static final String secret = "1KoOpQKyVv5Yxkj4LHxjBgLjpczO6L8P0lq87LDi";
-    private static final long expirationMs = 300000; // 5 perc
+public class RefreshUtil {
 
-    public static String createJWT(User user) {
+    private static final String secret = "olUo6BXAlnmeWQJA5NLMy8rISeO4qfkhlPL9P6FM";
+    private static final long refreshExpirationMs = 2592000000L; // 30 nap
+
+    public static String createRefreshToken(User user) {
         SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
         long nowMillis = System.currentTimeMillis();
         Date now = new Date(nowMillis);
-        Date expiration = new Date(nowMillis + expirationMs);
+        Date expiration = new Date(nowMillis + refreshExpirationMs);
         byte[] apiKeySecretBytes = secret.getBytes();
         return Jwts.builder()
                 .setSubject(user.getEmail())
@@ -28,19 +28,15 @@ public class JwtUtil {
                 .compact();
     }
 
-    public static String getEmailFromJWTToken(String token) {
+    public static String getEmailFromRefreshToken(String token) {
         byte[] apiKeySecretBytes = secret.getBytes();
         return Jwts.parser().setSigningKey(apiKeySecretBytes).parseClaimsJws(token).getBody().getSubject();
     }
 
     public static boolean isExpired(String token) {
-        try {
-            Claims claims = Jwts.parser().setSigningKey(secret.getBytes()).parseClaimsJws(token).getBody();
-            Date expirationDate = claims.getExpiration();
-            return expirationDate.before(new Date());
-        } catch (ExpiredJwtException error) {
-            return true;
-        }
-
+        Claims claims = Jwts.parser().setSigningKey(secret.getBytes()).parseClaimsJws(token).getBody();
+        Date expirationDate = claims.getExpiration();
+        return expirationDate.before(new Date());
     }
 }
+

--- a/src/main/java/com/example/pizzaproject/restexception/CustomRestExceptionMapper.java
+++ b/src/main/java/com/example/pizzaproject/restexception/CustomRestExceptionMapper.java
@@ -1,8 +1,0 @@
-package com.example.pizzaproject.restexception;
-
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-@RestControllerAdvice
-public class CustomRestExceptionMapper {
-
-}

--- a/src/main/java/com/example/pizzaproject/user/UserController.java
+++ b/src/main/java/com/example/pizzaproject/user/UserController.java
@@ -2,6 +2,9 @@ package com.example.pizzaproject.user;
 
 import com.example.pizzaproject.auth.JwtResponse;
 import com.example.pizzaproject.auth.JwtUtil;
+import com.example.pizzaproject.auth.RefreshRequest;
+import com.example.pizzaproject.auth.RefreshUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.sql.Ref;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,13 +35,11 @@ public class UserController {
 
     @PostMapping(path = "/register")
     public ResponseEntity<JwtResponse> registerNewUser(@RequestBody User user) {
-        try{
+        try {
             userService.addNewUser(user);
-            String token = JwtUtil.createJWT(user);
-            JwtResponse response = new JwtResponse("User created successfully", token);
-            return new ResponseEntity<>(response, HttpStatus.OK);
+            return UserService.createResponse(user);
         } catch (ResponseStatusException e) {
-            JwtResponse response = new JwtResponse("Error while creating user", null);
+            JwtResponse response = new JwtResponse("Error while creating user", null, null);
             return new ResponseEntity<>(response, e.getStatusCode());
         }
     }
@@ -46,12 +48,39 @@ public class UserController {
     public ResponseEntity<JwtResponse> login(@RequestBody User user) {
         Optional<User> foundUser = userService.findUserByEmailAndPassword(user.getEmail(), user.getPassword());
         if (foundUser.isPresent()) {
+            return UserService.createResponse(foundUser.get());
+        } else {
+            return UserService.createErrorResponse();
+        }
+    }
+
+    @PostMapping(path = "/admin-login", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<JwtResponse> adminlogin(@RequestBody User user) {
+        Optional<User> foundUser = userService.findUserByEmailAndPassword(user.getEmail(), user.getPassword());
+        if (foundUser.isPresent()) {
+            if (foundUser.get().isAdmin()) { // Check if user is an admin
+                return UserService.createResponse(foundUser.get());
+            } else {
+                // User is not an admin
+                return UserService.createErrorResponse();
+            }
+        } else {
+            // User not found
+            return UserService.createErrorResponse();
+        }
+    }
+
+    @PostMapping(path = "/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<JwtResponse> refresh(@RequestBody RefreshRequest request) {
+        String email = RefreshUtil.getEmailFromRefreshToken(request.getRefreshToken());
+        Optional<User> foundUser = userService.findUserByEmail(email);
+        if (foundUser.isPresent()) {
             String jwtToken = JwtUtil.createJWT(foundUser.get());
-            JwtResponse response = new JwtResponse("success",jwtToken);
+            String refreshToken = RefreshUtil.createRefreshToken(foundUser.get());
+            JwtResponse response = new JwtResponse("success", jwtToken, refreshToken);
             return new ResponseEntity<>(response, HttpStatus.OK);
         } else {
-            System.out.println("Email-jelszó páros nem passzol");
-            JwtResponse response = new JwtResponse("failure", null);
+            JwtResponse response = new JwtResponse("failure", null, null);
             return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
         }
     }
@@ -59,12 +88,14 @@ public class UserController {
     @GetMapping(path = "/data", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<User> getUserData(@RequestHeader("Authorization") String authorization) {
         String token = authorization.substring(7);
-        String email = JwtUtil.getEmailFromToken(token);
+        if (JwtUtil.isExpired(token)) {
+            //status code 451
+            return ResponseEntity.status(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS).body(null);
+        }
+        String email = JwtUtil.getEmailFromJWTToken(token);
         Optional<User> user = userService.findUserByEmail(email);
         if (user.isPresent()) {
-            User userData = new User(user.get().getId(), user.get().getFirst_name(), user.get().getLast_name(), user.get().getEmail(), user.get().getPassword(), user.get().isAdmin());
-            System.out.println(userData);
-            return new ResponseEntity<>(userData, HttpStatus.OK);
+            return new ResponseEntity<>(user.get(), HttpStatus.OK);
         } else {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
@@ -72,7 +103,7 @@ public class UserController {
 
     @GetMapping("/email")
     public String getEmailByToken(@RequestHeader("Authorization") String token) {
-        String email = JwtUtil.getEmailFromToken(token);
+        String email = JwtUtil.getEmailFromJWTToken(token);
         return email;
     }
 
@@ -85,8 +116,8 @@ public class UserController {
     @PutMapping(path = "{userId}")
     public ResponseEntity<String> updateUser(
             @PathVariable("userId") Long userId,
-            @RequestBody(required = false) User user){
-        try{
+            @RequestBody(required = false) User user) {
+        try {
             userService.updateUser(userId, user);
             return new ResponseEntity<>("User updated successfully", HttpStatus.OK);
         } catch (IllegalStateException e) {

--- a/src/main/java/com/example/pizzaproject/user/UserService.java
+++ b/src/main/java/com/example/pizzaproject/user/UserService.java
@@ -4,10 +4,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.example.pizzaproject.auth.JwtResponse;
+import com.example.pizzaproject.auth.JwtUtil;
+import com.example.pizzaproject.auth.RefreshUtil;
 import jakarta.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -51,6 +55,18 @@ public class UserService {
             return user;
         }
         return Optional.empty();
+    }
+
+    public static ResponseEntity<JwtResponse> createResponse(User user) {
+        String jwtToken = JwtUtil.createJWT(user);
+        String refreshToken = RefreshUtil.createRefreshToken(user);
+        JwtResponse response = new JwtResponse("success",jwtToken, refreshToken);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    public static ResponseEntity<JwtResponse> createErrorResponse() {
+        JwtResponse response = new JwtResponse("failure", null, null);
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
     }
 
     public void deleteUser(Long userId) {


### PR DESCRIPTION
Magyarul írom mert fáradt vagyok:

Refresh token generálása ami 30 percig él.
Access token generálása ami 5 percig él.
JwtResponse elküldi mind a két kódot bejelentkezéskor illetve adat lekérésnél megkapja az access tokent. Ha lejárt visszaküld egy 451-es hibakódot (frontend kezeli és kér egy új tokent ('/refresh'))

Restexceptionmappert kitöröltem mert üres volt.

Admin login request ami ugyan az mint a login csak megnézi hogy admin e és abban az esetben küldi el a tokeneket.

createErrorResponse és createResponse függvények a UserService-be kiszedve a duplikálás elkerülése és az átláthatóbb kód végett.